### PR TITLE
Implement stubbed Supabase auth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+node_modules

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,10 @@
+import LoginForm from '../../components/LoginForm';
+
+export default function LoginPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-8">
+      <h1 className="text-2xl mb-4">Login</h1>
+      <LoginForm />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ export default function Home() {
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+        <a href="/login" className="underline text-sm self-end">Login</a>
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useState } from 'react';
+import { signInWithEmail } from '../lib/supabase';
+
+export default function LoginForm() {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await signInWithEmail(email);
+      setMessage('Check your email for a login link.');
+    } catch (err) {
+      setMessage('Failed to send magic link');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-xs">
+      <input
+        type="email"
+        required
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="you@example.com"
+        className="border p-2 rounded"
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className="bg-black text-white rounded p-2 disabled:opacity-50"
+      >
+        Send Magic Link
+      </button>
+      {message && <p className="text-sm mt-2">{message}</p>}
+    </form>
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,43 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error('Supabase environment variables are missing');
+}
+
+export async function signInWithEmail(email: string) {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/magiclink`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: SUPABASE_ANON_KEY,
+    },
+    body: JSON.stringify({ email }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to send magic link');
+  }
+  return res.json();
+}
+
+export async function signOut(accessToken: string) {
+  await fetch(`${SUPABASE_URL}/auth/v1/logout`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+}
+
+export async function getUser(accessToken: string) {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add skeleton Supabase client in `src/lib`
- create `LoginForm` component and `/login` route
- link to login page from home screen
- ignore `node_modules` so it is not tracked

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*