### PR TITLE
Fix unused var lint error

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -13,7 +13,8 @@ export default function LoginForm() {
     try {
       await signInWithEmail(email);
       setMessage('Check your email for a login link.');
-    } catch (err) {
+    } catch (error) {
+      console.error(error);
       setMessage('Failed to send magic link');
     }
     setLoading(false);


### PR DESCRIPTION
## Summary
- handle caught error variable so eslint passes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*